### PR TITLE
Update core.yml protections for new Material names

### DIFF
--- a/src/config/core.yml
+++ b/src/config/core.yml
@@ -171,9 +171,11 @@ protections:
         sign:
             enabled: true
             autoRegister: private
+        iron_door:
+            enabled: true
         wooden_door:
             enabled: true
-        iron_door:
+        oak_door:
             enabled: true
         spruce_door:
             enabled: true
@@ -185,11 +187,25 @@ protections:
             enabled: true
         dark_oak_door:
             enabled: true
-        trap_door:
-            enabled: true
         iron_trapdoor:
             enabled: true
+        trap_door:
+            enabled: true
+        oak_trapdoor:
+            enabled: true
+        spruce_trapdoor:
+            enabled: true
+        birch_trapdoor:
+            enabled: true
+        jungle_trapdoor:
+            enabled: true
+        acacia_trapdoor:
+            enabled: true
+        dark_oak_trapdoor:
+            enabled: true
         fence_gate:
+            enabled: true
+        oak_fence_gate:
             enabled: true
         spruce_fence_gate:
             enabled: true


### PR DESCRIPTION
* Added the new alternate wooden variants of trapdoors
* Added the new IDs for normal doors and fence gates (`oak_door` and `oak_fence_gate` respectively)
* Left the old IDs in the config (`wooden_door`, `trap_door`, and `fence_gate`) to maintain potential compatibility with older versions.